### PR TITLE
Rework backend API

### DIFF
--- a/src/card.py
+++ b/src/card.py
@@ -1,10 +1,10 @@
-import json
-#Implementation of a standard Poker card, with ability to output to JSON
-class Card:
-    def __init__(self, rank, suit):
-        self.rank = {"rank": rank}
-        self.suit = {"suit": suit}
+from typing import NamedTuple
 
-    def to_json(self):
-         return json.dumps({"rank": self.rank, 
-                            "suit": self.suit})
+
+class Card(NamedTuple):
+    """
+    Represents a playing card.
+    """
+
+    rank: str
+    suit: str

--- a/src/deck.py
+++ b/src/deck.py
@@ -1,27 +1,35 @@
 from card import Card
 import random
+from dataclasses import dataclass, field
+from functools import partial
+
 SUITS = ["C", "D", "H", "S"]
 RANKS = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]
+CARDS = [Card(rank=r, suit=s) for r in RANKS for s in SUITS]
 
-#TODO: implement ranking
+
+# TODO: implement ranking
+@dataclass
 class Deck:
-    def __init__(self):
-        self.cards = []
-        for suit in (SUITS):
-            for rank in (RANKS):
-                card = Card(rank, suit)
-                self.cards.append(card.to_json)
-                
-        random.shuffle(self.cards)
-    
-    def pop(self):
-        return self.cards.pop()
-    
-    def draw(self, num):
-        cards_drawn = []
-        #if(self.cards.__sizeof__ < num):
-            #num = self.cards.__sizeof__
-        for _ in range(num):
-            cards_drawn.append(self.pop())
-        return cards_drawn
+    cards: list[Card] = field(
+        default_factory=partial(random.sample, CARDS, len(CARDS))
+    )
+    top: int = 0
 
+    def pop(self) -> dict[str, str]:
+        card = self.cards[self.top]
+        self.top += 1
+        return card._asdict()
+
+    def draw(self, num: int) -> list[dict[str, str]]:
+        return [self.pop() for _ in range(num)]
+
+    def to_serializable(self) -> list[dict[str, str]]:
+        return [c._asdict() for c in self.cards]
+
+    @property
+    def cards_left(self) -> int:
+        """
+        Returns the number of cards left in the deck.
+        """
+        return len(self.cards) - self.top


### PR DESCRIPTION
## 1) What is included in this change?

This change reworks the backend API from #3 to get it functioning with the changes requested. Some of the code is also cleaned up and formatted with Black. Token generation uses Python's built-in `secrets.token_urlsafe` with an explicitly passed-in 128-bit (16-byte) deck ID. That number of bits should be enough for our purposes, since it'd take a lot of time for even a 50% chance of a collision.

As for the API endpoints, the only changes are:

1. `restart-game` returns a 404 error when the deck ID isn't found.
2. `deal` returns a 500 error if the deck has no cards left. It also doesn't return `cards` inside of `dealt_cards`; it just returns a `cards` object with a list of them.

## 2) Describe at least one problem you solved

There were bugs in the v2 API, including wonky attempted JSON formatting and a failure to do so resulting in cards being empty.

## 3) How did you test this change?

I manually used CURL to simulate a client and tested the endpoints, their dates, and queried the internal deck to ensure it was, in fact, returning the cards it should be. This process could definitely be automated.