### PR TITLE
UI: update to API v2, add deck sessionStorage

### DIFF
--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -45,23 +45,26 @@ export default function App({ initialCards, initialDeck, initialEnded }) {
     }
   }, [initialCards, initialDeck, cards, selected, deck, dealt, error]);
 
-  function toggleSelected(index) {
-    if (dealt) {
-      setSelected([]);
-      return;
-    }
-    const newSelected = selected.concat([index]);
-    const remaining = [0, 1, 2, 3, 4].filter((e) => !newSelected.includes(e));
-    if (
-      (selected.length >= 3 &&
-        (remaining.length == 0 || cards[remaining[0]].rank !== "A")) ||
-      selected.includes(index)
-    ) {
-      setSelected(selected.filter((elt) => elt !== index));
-    } else {
-      setSelected(newSelected);
-    }
-  }
+  const toggleSelected = useCallback(
+    (index) => {
+      if (dealt) {
+        setSelected([]);
+        return;
+      }
+      const newSelected = selected.concat([index]);
+      const remaining = [0, 1, 2, 3, 4].filter((e) => !newSelected.includes(e));
+      if (
+        (selected.length >= 3 &&
+          (remaining.length == 0 || cards[remaining[0]].rank !== "A")) ||
+        selected.includes(index)
+      ) {
+        setSelected(selected.filter((elt) => elt !== index));
+      } else {
+        setSelected(newSelected);
+      }
+    },
+    [dealt, selected],
+  );
 
   // This function will be called when the Draw button is clicked
   const fetchNewCards = useCallback(async () => {

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -29,11 +29,11 @@ export default function App({ initialCards, initialDeck, initialEnded }) {
         setCards(result);
         setDeck(d);
         setError(false);
+        setSelected([]);
+        setDealt(false);
       });
-      setSelected([]);
-      setDealt(false);
     }
-  }, [initialCards, initialDeck, cards, selected, deck, dealt, error]);
+  }, [error]);
 
   useEffect(() => {
     if (!error) {

--- a/src/ui/Card.js
+++ b/src/ui/Card.js
@@ -1,4 +1,5 @@
 export default function Card({ rank, suit, selected, onClick }) {
+  if (rank == 10) rank = "0";
   return (
     <img
       className="card"

--- a/src/ui/Deck.js
+++ b/src/ui/Deck.js
@@ -1,0 +1,83 @@
+export class DeckNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "DeckNotFoundError";
+    }
+}
+
+export class Deck {
+    deckId;
+    expiry;
+
+    async init(id, expiry) {
+        if (
+            typeof id === "string" &&
+            typeof expiry === "object" &&
+            new Date() < expiry
+        ) {
+            this.deckId = id;
+            this.expiry = expiry;
+            const testresp = await fetch(`/api/v2/deck/${this.deckId}`, {
+                method: "HEAD",
+            });
+            if (testresp.ok) {
+                console.log("session storage worked.");
+                return;
+            }
+        }
+        const resp = await fetch("/api/v2/deck/new", { method: "POST" });
+        const response = await resp.json();
+        console.log(response);
+        this.deckId = response.deck_id;
+        this.expiry = new Date(response.expires * 1000);
+        return response.hand.cards;
+    }
+
+    clone() {
+        let d = new Deck();
+        d.init(this.deckId, this.expiry);
+        return d;
+    }
+
+    // WARNING: stateful
+    setSessionStorage() {
+        sessionStorage.setItem(
+            "deck",
+            JSON.stringify({
+                id: this.deckId,
+                expiry: this.expiry.getTime(),
+            }),
+        );
+    }
+
+    /*
+     * Throws an error if deck is expired.
+     */
+    check_expiry() {
+        if (new Date() > this.expiry) {
+            throw new DeckNotFoundError("deck is expired");
+        }
+    }
+
+    async deal(count) {
+        if (typeof count !== "number")
+            throw new Error("count must be a number.");
+        this.check_expiry();
+
+        const resp = await fetch(`/api/v2/deck/${this.deckId}/deal/${count}`, {
+            method: "POST",
+        });
+        const response = await resp.json();
+        return response.cards;
+    }
+
+    async restart() {
+        this.check_expiry();
+        const resp = await fetch(`/api/v2/deck/${this.deckId}/restart-game`, {
+            method: "POST",
+        });
+        const response = await resp.json();
+        this.expiry = new Date(response.expires * 1000);
+        return response.hand.cards;
+    }
+}

--- a/src/ui/main.js
+++ b/src/ui/main.js
@@ -1,29 +1,47 @@
-import { React, useState, useCallback } from "react";
+import { StrictMode, React, useState, useCallback } from "react";
 import { createRoot } from "react-dom/client";
 import Api from "./Api.js";
 import App from "./App.js";
+import { "Deck" as Deck } from "./Deck.js";
 
 async function main() {
-  const newDeck = await Api.deck();
-  console.log(newDeck);
+  // const newDeck = await Api.deck();
+  // console.log(newDeck);
 
   const fetchedDeck = await Api.deck("1234");
   console.log(fetchedDeck);
 
-  // let the server deal the hand
-  const initialCards = await Promise.all([
-    // note: this is still calling the v1 APIs
-    Api.deal(),
-    Api.deal(),
-    Api.deal(),
-    Api.deal(),
-    Api.deal(),
-  ]);
-  console.log(initialCards);
+  let deck = new Deck();
+  let d = sessionStorage.getItem("deck");
+  let initialCards = sessionStorage.getItem("hand");
+  let ended = false;
+  if (d) d = JSON.parse(d);
+  if (initialCards) JSON.parse(initialCards);
+  if (!d || !initialCards || new Date() < Date(d.expiry)) {
+    console.log("no session storage");
+    initialCards = await deck.init();
+    sessionStorage.setItem("hand", JSON.stringify(initialCards));
+  } else {
+    console.log("has session storage");
+    initialCards = await deck.init(d.id, new Date(d.expiry));
+    if (!initialCards) {
+      // session storage worked
+      initialCards = JSON.parse(sessionStorage.getItem("hand"));
+      ended = sessionStorage.getItem("dealt");
+      if (!ended) ended = false;
+    } else {
+      ended = false;
+    }
+  }
+
+  deck.setSessionStorage();
+  console.log("main deck: " + deck);
 
   // create React elements
   const root = createRoot(document.getElementById("app"));
-  root.render(<App initialCards={initialCards} />);
+  root.render(
+    <App initialCards={initialCards} initialDeck={deck} initialEnded={ended} />,
+  );
 }
 
 window.onload = main;


### PR DESCRIPTION
## 1) What is included in this change?

- Updated to API v2
- Implements business logic with how many cards can be drawn
- Adds a "Restart" button
- Automatically saves the hand and deck ID to session storage, so if they refresh the page they will still have their game. (Could be moved to `localStorage` later in principle.)
- Error handling is added for deck expiration (and attempts to handle generic errors) by restarting the game and fetching a new deck.

## 2) Describe at least one problem you solved

Switching the UI to the v2 API is the biggest fix, since it allows the server to return non-duplicate cards. Session storage likely falls under YAGNI, and the error handling is quite poor and might -- in the worst case -- cause infinite loops if the server is unresponsive or returning other errors. Further testing may be needed.

# 3) How did you test this change?

I ran the program and went through a few basic error cases. I set the deck expiration time to 2 minutes to see if that was handled gracefully (it printed an error message and restarted the game). I also tried shutting down the server completely, and after a request timeout it didn't seem to fall under an infinite loop, which is good. (I'm still a little scared, though.)

During testing I also used the React Developer Tools extension and copious amounts of `console.log`s to inspect whether session storage was being handled gracefully.

## 4) If things are not currently working, explain.

Error messages are a little vague when the server shuts down.

## 5) Pull requests that impact the UI should include screenshots.

First page load:

![](https://github.com/OliveRoquesUNCA/project1/assets/16159914/fb51a81f-8935-48fa-b15c-0ab557f1ef65)

Selected cards:

![](https://github.com/OliveRoquesUNCA/project1/assets/16159914/45f3e272-5eba-4f0e-bd2d-2d158178c25a)

After drawing:

![](https://github.com/OliveRoquesUNCA/project1/assets/16159914/d72aad4c-7ab8-423e-bd77-a4f1c0ab0380)

Client-side expiration detection:

![](https://github.com/OliveRoquesUNCA/project1/assets/16159914/073b1054-9b6d-4d57-b164-0383f246ea41)