### PR TITLE
Added ranking API endpoint and logic to check for it

### DIFF
--- a/src/deck.py
+++ b/src/deck.py
@@ -8,7 +8,6 @@ RANKS = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]
 CARDS = [Card(rank=r, suit=s) for r in RANKS for s in SUITS]
 
 
-# TODO: implement ranking
 @dataclass
 class Deck:
     cards: list[Card] = field(

--- a/src/server.py
+++ b/src/server.py
@@ -7,6 +7,7 @@ import time
 import json
 from datetime import datetime, timedelta
 from contextlib import asynccontextmanager
+from collections import Counter
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from deck import Deck
@@ -29,6 +30,7 @@ def generate_unique_deck_id() -> str:
         did = secrets.token_urlsafe(DECK_ID_BYTES)
         if did not in deck_objects:
             return did
+        
 
 
 @app.get("/api/v1/hello")
@@ -89,10 +91,6 @@ async def api_v2_deck_deal(deck_id: str, count: int):
     dealt_cards = d.draw(count)
     return {"cards": dealt_cards}
 
-
-# @app.post("/api/v2/get-state")
-
-
 # resets state of game associated with deck_id, making new Deck object, expiration date, and a new hand
 @app.post("/api/v2/deck/{deck_id}/restart-game")
 async def api_v2_deck_restart_game(deck_id: str):
@@ -108,6 +106,75 @@ async def api_v2_deck_restart_game(deck_id: str):
     expiration_times[deck_id] = expiration_time
     hand = d.draw(5)
     return {"hand": {"cards": hand}, "expires": expiration_time}
+
+# Hand string should be in format "[rank][suit],[rank][suit],...", each card 
+# represented by two characters without the brackets
+@app.get("/api/v2/deck/get-ranking")
+async def api_v2_deck_get_ranking(cards: str):
+    ranking = get_ranking(cards)
+    return {"ranking": ranking}
+
+def get_ranking(cards: str) -> str:
+    hand_list = cards.split(",")
+    ranks = [card[0] for card in hand_list]
+    suits = [card[1] for card in hand_list]
+
+    # Count occurrences of ranks, suits
+    rank_counts = Counter(ranks)
+    suit_counts = Counter(suits)
+
+    # Check for flush
+    is_flush = len(suit_counts) == 1
+
+    # Check for straight
+    #creates sorted ranks list to compare hand to
+    sorted_ranks = sorted(set(ranks), key= lambda x: '234567890JQKA'.index(x))
+
+    #compares 5 characters of comparison list to 5 characters in hand
+    is_straight = '23456789TJQKA'[
+        '23456789TJQKA'.index(sorted_ranks[0]):
+        '23456789TJQKA'.index(sorted_ranks[0]) + 5] == ''.join(sorted_ranks)
+    
+    # Check for straight flush
+    is_straight_flush = is_straight and is_flush
+    
+    # Check for four of a kind
+    is_four_of_a_kind = 4 in rank_counts.values()
+    
+    # Check for full house
+    is_full_house = sorted(rank_counts.values()) == [2, 3]
+    
+    # Check for three of a kind
+    is_three_of_a_kind = 3 in rank_counts.values()
+    
+    # Check for two pairs
+    is_two_pairs = list(rank_counts.values()).count(2) == 2
+    
+    # Check for one pair
+    is_one_pair = 2 in rank_counts.values()
+    
+    # Determine the hand ranking
+    if is_straight_flush:
+        return "Straight Flush"
+    elif is_four_of_a_kind:
+        return "Four of a Kind"
+    elif is_full_house:
+        return "Full House"
+    elif is_flush:
+        return "Flush"
+    elif is_straight:
+        return "Straight"
+    elif is_three_of_a_kind:
+        return "Three of a Kind"
+    elif is_two_pairs:
+        return "Two Pairs"
+    elif is_one_pair:
+        return "One Pair"
+    else:
+        return "High Card"
+
+
+
 
 
 app.mount("/", StaticFiles(directory="ui/dist", html=True), name="ui")

--- a/src/test.sh
+++ b/src/test.sh
@@ -10,6 +10,7 @@ deck_id=$(curl -s -X POST localhost:8000/api/v2/deck/new | jq -r '.deck_id')
 curl -w "\n" localhost:8000/api/v2/deck/$deck_id | jq -r '.cards, .top'
 curl -w "\n" -X POST localhost:8000/api/v2/deck/$deck_id/deal/4 | jq -r '.cards'
 curl -w "\n" -X POST localhost:8000/api/v2/deck/$deck_id/restart-game | jq -r '.hand, .expires'
+curl -w "\n" localhost:8000/api/v2/deck/get-ranking?cards=2C,3C,4C,5C,6C | jq -r '.ranking'
 
 # The `-w "\n"' argument adds a new line to the end of curl's output
 


### PR DESCRIPTION
### 1) What is included in this change?
A new API endpoint, /api/v2/deck/get-ranking (GET) allows for the front end to query for the ranking of a hand, with the query string being in the format of "[rank][suit],[rank][suit],...", where ranks and suits are one character each and separated by commas. This endpoint calls a local function, get_ranking, to parse the queried string for the poker ranking of the given 5 cards, and returns a string representing which poker hand it represents.
### 2) Describe at least one problem you solved
The question of how to keep track of the highest number of ranks/suits was the main issue, and the Counter class was an easy pick for that problem. Additionally, tracking straights was a major hurdle, requiring much googling and falling back on ChatGPT to get a workable solution for it.
### 3) How did you test this change?
I had trouble testing this change due to some bugs with jq, but the logic of the local function seems to work in a local python shell.
### 4) If things are not currently working, explain.
I was unable to test this in a server environment due to jq bugs, unfortunately. I am unsure if the query parameter is in the right format in the shell script.
